### PR TITLE
Add an espresso test to the 2_espresso example.

### DIFF
--- a/examples/2_espresso/build.gradle
+++ b/examples/2_espresso/build.gradle
@@ -10,6 +10,7 @@ android {
         targetSdkVersion 24
         versionCode 1
         versionName "0.0.1"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     productFlavors {
@@ -20,6 +21,17 @@ android {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:24.2.1'
+
+    // The androidTest package is not for snippet support; it shows an example
+    // of an instrumentation test coexisting with a snippet in the same
+    // codebase.
+    androidTestCompile 'com.android.support:support-annotations:24.2.1'
+    androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
+
     snippetCompile project(':third_party:sl4a')
     snippetCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     snippetCompile 'com.android.support:support-annotations:24.2.1'

--- a/examples/2_espresso/src/androidTest/java/com/google/android/mobly/snippet/example2/EspressoTest.java
+++ b/examples/2_espresso/src/androidTest/java/com/google/android/mobly/snippet/example2/EspressoTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.example2;
+
+import android.support.test.espresso.action.ViewActions;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+/**
+ * This test is not part of the snippet code. It's a regular espresso instrumentation test which
+ * shows how regular tests can coexist with snippets in the source tree.
+ */
+@RunWith(AndroidJUnit4.class)
+public class EspressoTest {
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityRule =
+            new ActivityTestRule<>(MainActivity.class);
+
+    @Test
+    public void espressoTest() {
+        onView(withId(R.id.main_text_view)).check(matches(withText("Hello World!")));
+        onView(withId(R.id.main_button)).perform(ViewActions.click());
+        onView(withId(R.id.main_text_view)).check(matches(withText("Button pressed 1 times")));
+    }
+}


### PR DESCRIPTION
This is to show how an espresso test can coexist with snippets in the
same codebase.