### PR TITLE
Propagate exceptions out of SimpleServer instead of returning null.

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetRunner.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetRunner.java
@@ -82,9 +82,12 @@ public class SnippetRunner extends AndroidJUnitRunner {
         try {
             androidProxy.startLocal(port);
         } catch (SocketException e) {
-            throw new RuntimeException("Failed to start server on port "
-                + port + ". No permission to create a socket. Does the *MAIN* app manifest "
-                + "declare the INTERNET permission?", e);
+            if (e.getMessage().equals("Permission denied")) {
+                throw new RuntimeException("Failed to start server on port "
+                    + port + ". No permission to create a socket. Does the *MAIN* app manifest "
+                    + "declare the INTERNET permission?", e);
+            }
+            throw new RuntimeException("Failed to start server on port " + port, e);
         } catch (IOException e) {
             throw new RuntimeException("Failed to start server on port " + port, e);
         }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetRunner.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetRunner.java
@@ -25,6 +25,8 @@ import android.support.test.runner.AndroidJUnitRunner;
 import com.google.android.mobly.snippet.rpc.AndroidProxy;
 import com.google.android.mobly.snippet.util.Log;
 import com.google.android.mobly.snippet.util.NotificationIdFactory;
+import java.io.IOException;
+import java.net.SocketException;
 
 /**
  * A launcher that starts the snippet server as an instrumentation so that it has access to the
@@ -77,8 +79,14 @@ public class SnippetRunner extends AndroidJUnitRunner {
 
     private void startServer(int port) {
         AndroidProxy androidProxy = new AndroidProxy(getContext());
-        if (androidProxy.startLocal(port) == null) {
-            throw new RuntimeException("Failed to start server on port " + port);
+        try {
+            androidProxy.startLocal(port);
+        } catch (SocketException e) {
+            throw new RuntimeException("Failed to start server on port "
+                + port + ". No permission to create a socket. Does the *MAIN* app manifest "
+                + "declare the INTERNET permission?", e);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to start server on port " + port, e);
         }
         createNotification();
         Log.i("Snippet server started for process " + Process.myPid() + " on port " + port);

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/AndroidProxy.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/AndroidProxy.java
@@ -21,11 +21,11 @@ import android.content.Context;
 import com.google.android.mobly.snippet.manager.ReflectionSnippetManagerFactory;
 import com.google.android.mobly.snippet.manager.SnippetManagerFactory;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 
 public class AndroidProxy {
 
-    private InetSocketAddress mAddress;
     private final JsonRpcServer mJsonRpcServer;
     private final SnippetManagerFactory mSnippetManagerFactory;
 
@@ -34,8 +34,7 @@ public class AndroidProxy {
         mJsonRpcServer = new JsonRpcServer(mSnippetManagerFactory);
     }
 
-    public InetSocketAddress startLocal(int port) {
-        mAddress = mJsonRpcServer.startLocal(port);
-        return mAddress;
+    public void startLocal(int port) throws IOException {
+        mJsonRpcServer.startLocal(port);
     }
 }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/SimpleServer.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/SimpleServer.java
@@ -191,33 +191,17 @@ public abstract class SimpleServer {
    * @param port
    *          the port to bind to or 0 to pick any unused port
    *
-   * @return the port that the server is bound to
    * @throws IOException
    */
-  public InetSocketAddress startLocal(int port) {
+  public void startLocal(int port) throws IOException {
     InetAddress address;
-    try {
-      // address = InetAddress.getLocalHost();
-      address = getPrivateInetAddress();
-      mServer = new ServerSocket(port, 5, address);
-    } catch (BindException e) {
-      Log.e("Port " + port + " already in use.");
-      try {
-        address = getPrivateInetAddress();
-        mServer = new ServerSocket(0, 5, address);
-      } catch (IOException e1) {
-        e1.printStackTrace();
-        return null;
-      }
-    } catch (Exception e) {
-      Log.e("Failed to start server.", e);
-      return null;
-    }
-    int boundPort = start();
-    return InetSocketAddress.createUnresolved(mServer.getInetAddress().getHostAddress(), boundPort);
+    // address = InetAddress.getLocalHost();
+    address = getPrivateInetAddress();
+    mServer = new ServerSocket(port, 5, address);
+    start();
   }
 
-  private int start() {
+  private void start() {
     mServerThread = new Thread() {
       @Override
       public void run() {
@@ -243,7 +227,6 @@ public abstract class SimpleServer {
     };
     mServerThread.start();
     Log.v("Bound to " + mServer.getInetAddress());
-    return mServer.getLocalPort();
   }
 
   private void startConnectionThread(final Socket sock) throws IOException, JSONException {


### PR DESCRIPTION
Improve the error message for a particular class of error caused by incorrect manifest.

Based on #7.