### PR TITLE
Fix exception handling in snippets.

### DIFF
--- a/examples/ex1_standalone_app/src/main/java/com/google/android/mobly/snippet/example1/ExampleSnippet2.java
+++ b/examples/ex1_standalone_app/src/main/java/com/google/android/mobly/snippet/example1/ExampleSnippet2.java
@@ -18,11 +18,17 @@ package com.google.android.mobly.snippet.example1;
 
 import com.google.android.mobly.snippet.Snippet;
 import com.google.android.mobly.snippet.rpc.Rpc;
+import java.io.IOException;
 
 public class ExampleSnippet2 implements Snippet {
     @Rpc(description = "Returns the given string with the prefix \"bar\"")
     public String getBar(String input) {
         return "bar " + input;
+    }
+
+    @Rpc(description = "Throws an exception")
+    public String throwSomething() throws IOException {
+        throw new IOException("Example exception from throwSomething()");
     }
 
     @Override

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcResult.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcResult.java
@@ -16,6 +16,8 @@
 
 package com.google.android.mobly.snippet.rpc;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -48,10 +50,14 @@ public class JsonRpcResult {
   }
 
   public static JSONObject error(int id, Throwable t) throws JSONException {
+    StringWriter stackTraceWriter = new StringWriter();
+    t.printStackTrace(new PrintWriter(stackTraceWriter));
+    String stackTrace = stackTraceWriter.toString();
+
     JSONObject json = new JSONObject();
     json.put("id", id);
     json.put("result", JSONObject.NULL);
-    json.put("error", t.toString());
+    json.put("error", stackTrace);
     return json;
   }
 }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcResult.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcResult.java
@@ -51,7 +51,9 @@ public class JsonRpcResult {
 
   public static JSONObject error(int id, Throwable t) throws JSONException {
     StringWriter stackTraceWriter = new StringWriter();
+    stackTraceWriter.write("\n-------------- Java Stacktrace ---------------\n");
     t.printStackTrace(new PrintWriter(stackTraceWriter));
+    stackTraceWriter.write("----------------------------------------------");
     String stackTrace = stackTraceWriter.toString();
 
     JSONObject json = new JSONObject();

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
@@ -88,17 +88,7 @@ public final class MethodDescriptor {
       }
     }
 
-    return invoke(manager, args);
-  }
-
-  private Object invoke(SnippetManager manager, Object[] args) throws Throwable {
-    Object result;
-    try {
-      result = manager.invoke(mClass, mMethod, args);
-    } catch (Throwable t) {
-      throw t.getCause();
-    }
-    return result;
+    return manager.invoke(mClass, mMethod, args);
   }
 
   /**


### PR DESCRIPTION
* Don't try to call methods on snippet classes that couldn't be constructed
* Don't obscure the cause of exceptions
* Propagate the entire stack trace to the python side