### PR TITLE
Use double-checked locking instead of 'synchronized' in EventCache.

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/event/EventCache.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/event/EventCache.java
@@ -42,9 +42,13 @@ public class EventCache {
 
     private EventCache() {}
 
-    public static synchronized EventCache getInstance() {
+    public static EventCache getInstance() {
         if (mEventCache == null) {
-            mEventCache = new EventCache();
+            synchronized (EventCache.class) {
+                if (mEventCache == null) {
+                    mEventCache = new EventCache();
+                }
+            }
         }
         return mEventCache;
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/52)
<!-- Reviewable:end -->
