### PR TITLE
Group methods in help() by class.

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcServer.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcServer.java
@@ -142,7 +142,7 @@ public class JsonRpcServer extends SimpleServer {
         }
         StringBuilder result = new StringBuilder();
         for (Map.Entry<String, Set<MethodDescriptor>> entry : methods.entrySet()) {
-            result.append("\nMethods in class ").append(entry.getKey()).append(":\n");
+            result.append("\nRPC Methods in ").append(entry.getKey()).append(":\n");
             for (MethodDescriptor descriptor : entry.getValue()) {
                 result.append("  ").append(descriptor.getHelp()).append("\n");
             }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcServer.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcServer.java
@@ -22,7 +22,10 @@ import com.google.android.mobly.snippet.util.Log;
 import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.net.Socket;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -124,10 +127,25 @@ public class JsonRpcServer extends SimpleServer {
 
     private void help(PrintWriter writer, int id, SnippetManager receiverManager, Integer UID)
             throws JSONException {
-        StringBuilder result = new StringBuilder("Known methods:\n");
+        // Create a map from class simple name to the methods inside it.
+        Map<String, Set<MethodDescriptor>> methods = new TreeMap<>();
         for (String method : receiverManager.getMethodNames()) {
             MethodDescriptor descriptor = receiverManager.getMethodDescriptor(method);
-            result.append("  ").append(descriptor.getHelp()).append("\n");
+            String snippetClassName = descriptor.getSnippetClass().getSimpleName();
+            Set<MethodDescriptor> snippetClassMethods = methods.get(snippetClassName);
+            if (snippetClassMethods == null) {
+                // Preserve insertion order (alphabetical)
+                snippetClassMethods = new LinkedHashSet<>();
+                methods.put(snippetClassName, snippetClassMethods);
+            }
+            snippetClassMethods.add(descriptor);
+        }
+        StringBuilder result = new StringBuilder();
+        for (Map.Entry<String, Set<MethodDescriptor>> entry : methods.entrySet()) {
+            result.append("\nMethods in class ").append(entry.getKey()).append(":\n");
+            for (MethodDescriptor descriptor : entry.getValue()) {
+                result.append("  ").append(descriptor.getHelp()).append("\n");
+            }
         }
         send(writer, JsonRpcResult.result(id, result), UID);
     }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcServer.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonRpcServer.java
@@ -142,7 +142,7 @@ public class JsonRpcServer extends SimpleServer {
         }
         StringBuilder result = new StringBuilder();
         for (Map.Entry<String, Set<MethodDescriptor>> entry : methods.entrySet()) {
-            result.append("\nRPC Methods in ").append(entry.getKey()).append(":\n");
+            result.append("\nRPCs provided by ").append(entry.getKey()).append(":\n");
             for (MethodDescriptor descriptor : entry.getValue()) {
                 result.append("  ").append(descriptor.getHelp()).append("\n");
             }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
@@ -226,7 +226,8 @@ public final class MethodDescriptor {
         }
         String help =
                 String.format(
-                        "%s(%s) returns %s  // %s",
+                        "%s %s(%s) returns %s  // %s",
+                        isAsync() ? "@AsyncRpc" : "@Rpc",
                         mMethod.getName(),
                         paramBuilder,
                         mMethod.getReturnType().getSimpleName(),

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
@@ -198,6 +198,10 @@ public final class MethodDescriptor {
         return mMethod.isAnnotationPresent(AsyncRpc.class);
     }
 
+    public Class<? extends Snippet> getSnippetClass() {
+        return mClass;
+    }
+
     private String getAnnotationDescription() {
         if (isAsync()) {
             AsyncRpc annotation = mMethod.getAnnotation(AsyncRpc.class);


### PR DESCRIPTION
Example:
```
>>> print s.help()

Methods in class EventSnippet:
  eventGetAll(String, String) returns List  // Gets and removes all the events of a certain name that have been received so far. Non-blocking. Potentially racey since it does not guarantee no event of the same name will occur after the call.
  eventWaitAndGet(String, String, Integer) returns JSONObject  // Blocks until an event of a specified type has been received. The returned event is removed from the cache. Default timeout is 60s.

Methods in class ExampleSnippet:
  getFoo(Integer) returns String  // Returns the given integer with the prefix "foo"

Methods in class ExampleSnippet2:
  getBar(String) returns String  // Returns the given string with the prefix "bar"
  throwSomething() returns String  // Throws an exception
  throwSomethingFromMainThread() returns String  // Throws an exception from the main thread

```
Fixes #44.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/57)
<!-- Reviewable:end -->
