### PR TITLE
When launching snippet, propagate messages to instrumentation output.

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetRunner.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetRunner.java
@@ -42,13 +42,12 @@ public class SnippetRunner extends AndroidJUnitRunner {
     /**
      * Version of the launch and communication protocol between snippet and client.
      *
-     * <p>This should be incremented whenever the snippet bringup process changes in a way which is
-     * not backwards compatible with existing clients.
+     * <p>This should be incremented whenever the snippet bringup process changes.
      *
      * <p>Protocol descriptions:
      *
      * <ul>
-     *   <li>v1 (not reported):
+     *   <li>v0 (not reported):
      *       <ul>
      *         <li>Launch as Instrumentation with SnippetRunner.
      *         <li>No protocol-specific messages reported through instrumentation output.
@@ -56,13 +55,13 @@ public class SnippetRunner extends AndroidJUnitRunner {
      *         <li>'start' action prints nothing.
      *       </ul>
      *
-     *   <li>v2:
+     *   <li>v1: New instrumentation output added to track bringup process
      *       <ul>
-     *         <li>"HELLO &lt;protocol&gt;" added to instrumentation output upon snippet start
-     *         <li>"SERVING &lt;port&gt;" added to instrumentation output once server is ready
+     *         <li>"SNIPPET START, PROTOCOL &lt;protocol&gt;" upon snippet start
+     *         <li>"SNIPPET SERVING, PORT &lt;port&gt;" once server is ready
      *       </ul>
      */
-    public static final int PROTOCOL_VERSION = 2;
+    public static final int PROTOCOL_VERSION = 1;
 
     private static final String ARG_ACTION = "action";
     private static final String ARG_PORT = "port";
@@ -83,7 +82,7 @@ public class SnippetRunner extends AndroidJUnitRunner {
         mArguments = arguments;
 
         // First order of business is to report HELLO to instrumentation output.
-        sendString("HELLO " + PROTOCOL_VERSION);
+        sendString("SNIPPET START, PROTOCOL " + PROTOCOL_VERSION);
 
         // First-run static setup
         Log.initLogTag(getContext());
@@ -137,7 +136,7 @@ public class SnippetRunner extends AndroidJUnitRunner {
         }
         createNotification();
         int actualPort = androidProxy.getPort();
-        sendString("SERVING " + actualPort);
+        sendString("SNIPPET SERVING, PORT " + actualPort);
         Log.i("Snippet server started for process " + Process.myPid() + " on port " + actualPort);
     }
 

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetRunner.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetRunner.java
@@ -37,31 +37,44 @@ import java.net.SocketException;
  * snippets are launched with 'am instrument'. We're specifically extending {@link
  * AndroidJUnitRunner} because Espresso requires being called through it, since it sets up {@link
  * android.support.test.InstrumentationRegistry} which Espresso requires.
+ *
+ * <p>The launch and communication protocol between snippet and client is versionated and reported
+ * as follows:
+ *
+ * <ul>
+ *   <li>v0 (not reported):
+ *       <ul>
+ *         <li>Launch as Instrumentation with SnippetRunner.
+ *         <li>No protocol-specific messages reported through instrumentation output.
+ *         <li>'stop' action prints 'OK (0 tests)'
+ *         <li>'start' action prints nothing.
+ *       </ul>
+ *
+ *   <li>v1.0: New instrumentation output added to track bringup process
+ *       <ul>
+ *         <li>"SNIPPET START, PROTOCOL &lt;major&gt; &lt;minor&gt;" upon snippet start
+ *         <li>"SNIPPET SERVING, PORT &lt;port&gt;" once server is ready
+ *       </ul>
+ *
+ * </ul>
  */
 public class SnippetRunner extends AndroidJUnitRunner {
+
     /**
-     * Version of the launch and communication protocol between snippet and client.
+     * Major version of the launch and communication protocol.
      *
-     * <p>This should be incremented whenever the snippet bringup process changes.
-     *
-     * <p>Protocol descriptions:
-     *
-     * <ul>
-     *   <li>v0 (not reported):
-     *       <ul>
-     *         <li>Launch as Instrumentation with SnippetRunner.
-     *         <li>No protocol-specific messages reported through instrumentation output.
-     *         <li>'stop' action prints 'OK (0 tests)'
-     *         <li>'start' action prints nothing.
-     *       </ul>
-     *
-     *   <li>v1: New instrumentation output added to track bringup process
-     *       <ul>
-     *         <li>"SNIPPET START, PROTOCOL &lt;protocol&gt;" upon snippet start
-     *         <li>"SNIPPET SERVING, PORT &lt;port&gt;" once server is ready
-     *       </ul>
+     * <p>Incrementing this means that compatibility with clients using the older version is broken.
+     * Avoid breaking compatibility unless there is no other choice.
      */
-    public static final int PROTOCOL_VERSION = 1;
+    public static final int PROTOCOL_MAJOR_VERSION = 1;
+
+    /**
+     * Minor version of the launch and communication protocol.
+     *
+     * <p>Increment this when new features are added to the launch and communication protocol that
+     * are backwards compatible with the old protocol and don't break existing clients.
+     */
+    public static final int PROTOCOL_MINOR_VERSION = 0;
 
     private static final String ARG_ACTION = "action";
     private static final String ARG_PORT = "port";
@@ -81,11 +94,12 @@ public class SnippetRunner extends AndroidJUnitRunner {
     public void onCreate(Bundle arguments) {
         mArguments = arguments;
 
-        // First order of business is to report HELLO to instrumentation output.
-        sendString("SNIPPET START, PROTOCOL " + PROTOCOL_VERSION);
-
         // First-run static setup
         Log.initLogTag(getContext());
+
+        // First order of business is to report HELLO to instrumentation output.
+        sendString(
+                "SNIPPET START, PROTOCOL " + PROTOCOL_MAJOR_VERSION + " " + PROTOCOL_MINOR_VERSION);
 
         // Prevent this runner from triggering any real JUnit tests in the snippet by feeding it a
         // hardcoded empty test class.
@@ -152,6 +166,7 @@ public class SnippetRunner extends AndroidJUnitRunner {
     }
 
     private void sendString(String string) {
+        Log.i("Sending protocol message: " + string);
         Bundle bundle = new Bundle();
         bundle.putString(Instrumentation.REPORT_KEY_STREAMRESULT, string + "\n");
         sendStatus(0, bundle);

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/AndroidProxy.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/AndroidProxy.java
@@ -34,4 +34,8 @@ public class AndroidProxy {
     public void startLocal(int port) throws IOException {
         mJsonRpcServer.startLocal(port);
     }
+
+    public int getPort() {
+        return mJsonRpcServer.getPort();
+    }
 }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/SimpleServer.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/SimpleServer.java
@@ -192,8 +192,12 @@ public abstract class SimpleServer {
      */
     public void startLocal(int port) throws IOException {
         InetAddress address = getPrivateInetAddress();
-        mServer = new ServerSocket(port, 5, address);
+        mServer = new ServerSocket(port, 5 /* backlog */, address);
         start();
+    }
+
+    public int getPort() {
+        return mServer.getLocalPort();
     }
 
     private void start() {


### PR DESCRIPTION
Current messages are:

`SNIPPET START, PROTOCOL <major> <minor>` immediately once snippet starts
`SERVING <port id>` once the server has been successfully launched

This allows us to:
- Know that a snippet launched (versus crashing immediately due to e.g.
  classpath issues, so we don't need to bother trying to connect to a dead
  snippet
- Know what version of startup and communication protocol it's using so we
  can configure the client appropriately and manage compatibility.
- Allow the device side to choose a port number, to avoid the client side
  having to pick a port number for the snippet and hoping it's free.

Fixes #10.
Fixes #62.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/59)
<!-- Reviewable:end -->
