### PR TITLE
Fix a typo in the Espresso example README.md

### DIFF
--- a/examples/ex2_espresso/README.md
+++ b/examples/ex2_espresso/README.md
@@ -97,7 +97,7 @@ The snippet code cannot run from a regular test apk because it requires a custom
 
     ```python
     def test_click_button(self):
-      self.dut1.snippet.clickMainButton()
+      self.dut1.snippet.pushMainButton()
     ```
 
 ## Running the example code


### PR DESCRIPTION
The snippet function is called "pushMainButton", but the call site calls "clickMainButton".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/71)
<!-- Reviewable:end -->
