### PR TITLE
Walk up the stack trace from the correct index

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/util/Log.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/util/Log.java
@@ -28,6 +28,12 @@ public final class Log {
     private static final String MY_CLASS_NAME = Log.class.getName();
     private static final String ANDROID_LOG_CLASS_NAME = android.util.Log.class.getName();
 
+    // Skip the first two entries in stack trace when trying to infer the caller.
+    // The first two entries are:
+    // - dalvik.system.VMStack.getThreadStackTrace(Native Method)
+    // - java.lang.Thread.getStackTrace(Thread.java:580)
+    private static final int STACK_TRACE_WALK_START_INDEX = 2;
+
     private Log() {}
 
     public static synchronized void initLogTag(Context context) {
@@ -67,8 +73,7 @@ public final class Log {
         // android.util.Log: that's the caller.
         // Do not used hard-coded stack depth: that does not work all the time because of proguard
         // inline optimization.
-        // Skip the first 2 entries added by Thread.currentThread().getStackTrace().
-        for (int i = 2; i < stackTraceElements.length; i++) {
+        for (int i = STACK_TRACE_WALK_START_INDEX; i < stackTraceElements.length; i++) {
           StackTraceElement element = stackTraceElements[i];
           fullClassName = element.getClassName();
           if (!fullClassName.equals(MY_CLASS_NAME) &&

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/util/Log.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/util/Log.java
@@ -67,7 +67,9 @@ public final class Log {
         // android.util.Log: that's the caller.
         // Do not used hard-coded stack depth: that does not work all the time because of proguard
         // inline optimization.
-        for (StackTraceElement element : stackTraceElements) {
+        // Skip the first 2 entries added by Thread.currentThread().getStackTrace().
+        for (int i = 2; i < stackTraceElements.length; i++) {
+          StackTraceElement element = stackTraceElements[i];
           fullClassName = element.getClassName();
           if (!fullClassName.equals(MY_CLASS_NAME) &&
               !fullClassName.equals(ANDROID_LOG_CLASS_NAME)) {

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/util/Log.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/util/Log.java
@@ -32,6 +32,9 @@ public final class Log {
     // The first two entries are:
     // - dalvik.system.VMStack.getThreadStackTrace(Native Method)
     // - java.lang.Thread.getStackTrace(Thread.java:580)
+    // The {@code getStackTrace()} function returns the stack trace at where the trace is collected
+    // (inisde the JNI function {@code getThreadStackTrace()} instead of at where the {@code
+    // getStackTrace()} is called (althrought this is the natual expectation).
     private static final int STACK_TRACE_WALK_START_INDEX = 2;
 
     private Log() {}


### PR DESCRIPTION
The first two entries in the stack trace are generated by the call of getStackTrace(), and should be skipped while finding the caller. Fix #75 

dalvik.system.VMStack.getThreadStackTrace(Native Method)
java.lang.Thread.getStackTrace(Thread.java:580)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/76)
<!-- Reviewable:end -->
