### PR TITLE
Support custom converters of non-primitive types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,6 @@ mobly snippet lib along with detailed tutorials.
 *   [ex5_schedule_rpc](examples/ex5_schedule_rpc): Example of how to use the
     'scheduleRpc' RPC to execute another RPC at a later time, potentially after
     device disconnection.
+*   [ex6_complex_type_conversion](examples/ex6_complex_type_conversion): Example of how to pass a
+    non-primitive type to the Rpc methods and return non-promitive type from Rpc methods by
+    supplying a type converter.

--- a/README.md
+++ b/README.md
@@ -62,5 +62,5 @@ mobly snippet lib along with detailed tutorials.
     'scheduleRpc' RPC to execute another RPC at a later time, potentially after
     device disconnection.
 *   [ex6_complex_type_conversion](examples/ex6_complex_type_conversion): Example of how to pass a
-    non-primitive type to the Rpc methods and return non-promitive type from Rpc methods by
+    non-primitive type to the Rpc methods and return non-primitive type from Rpc methods by
     supplying a type converter.

--- a/examples/ex1_standalone_app/src/main/java/com/google/android/mobly/snippet/example6/ExampleSnippet.java
+++ b/examples/ex1_standalone_app/src/main/java/com/google/android/mobly/snippet/example6/ExampleSnippet.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.example6;
+
+import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.rpc.Rpc;
+
+public class ExampleSnippet implements Snippet {
+    @Rpc(description = "Returns the given integer with the prefix \"foo\"")
+    public String getFoo(Integer input) {
+        return "foo " + input;
+    }
+
+    @Override
+    public void shutdown() {}
+}

--- a/examples/ex1_standalone_app/src/main/java/com/google/android/mobly/snippet/example6/ExampleSnippet2.java
+++ b/examples/ex1_standalone_app/src/main/java/com/google/android/mobly/snippet/example6/ExampleSnippet2.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.example6;
+
+import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.rpc.Rpc;
+
+import com.google.android.mobly.snippet.rpc.RunOnUiThread;
+import java.io.IOException;
+
+public class ExampleSnippet2 implements Snippet {
+    @Rpc(description = "Returns the given string with the prefix \"bar\"")
+    public String getBar(String input) {
+        return "bar " + input;
+    }
+
+    @Rpc(description = "Throws an exception")
+    public String throwSomething() throws IOException {
+        throw new IOException("Example exception from throwSomething()");
+    }
+
+    @Rpc(description = "Throws an exception from the main thread")
+    // @RunOnUiThread makes this method execute on the main thread, but only has effect when
+    // invoked as an RPC. It does not affect how this method executes if invoked directly in Java.
+    // This annotation can also be applied to the constructor and the shutdown() method.
+    @RunOnUiThread
+    public String throwSomethingFromMainThread() throws IOException {
+        throw new IOException("Example exception from throwSomethingFromMainThread()");
+    }
+
+    @Override
+    public void shutdown() {}
+}

--- a/examples/ex6_complex_type_conversion/README.md
+++ b/examples/ex6_complex_type_conversion/README.md
@@ -1,0 +1,108 @@
+# Complex Type Conversion in Snippet Example
+
+This tutorial shows you how to use a custom object in Snippet Lib.
+
+This example assumes basic familiarity with Snippet Lib as demonstrated in
+[Example 1](../ex1_standalone_app/README.md).
+
+## Tutorial
+
+1.  Use Android Studio to create a new app project, similar to
+    [Example 1](../ex1_standalone_app/README.md).
+
+1.  Create a complex type in Java:
+    ```java
+    public class CustomType {
+        private String myValue;
+        CustomType(String value) {
+            myValue = value;
+        }
+    
+        String getMyValue() {
+            return myValue;
+        }
+        public void setMyValue(String newValue) {
+            myValue = newValue;
+        }
+    }
+    ```
+1.  Create a Java class implementing `SnippetObjectConverter`, which defines how the complex type
+    should be converted against `JSONObject`:
+    ```java
+    public class ExampleObjectConverter implements SnippetObjectConverter {
+        @Override
+        public JSONObject serialize(Object object) throws JSONException {
+            JSONObject result = new JSONObject();
+            if (object instanceof CustomType) {
+                CustomType input = (CustomType) object;
+                result.put("Value", input.getMyValue());
+                return result;
+            }
+            return null;
+        }
+    
+        @Override
+        public Object deserialize(JSONObject jsonObject, Type type) throws JSONException {
+            if (type == CustomType.class) {
+                return new CustomType(jsonObject.getString("Value"));
+            }
+            return null;
+        }
+    }
+    ```
+1.  Write a Java class implementing `Snippet` and add Rpc methods that takes your complex type as
+    a parameter and another Rpc method that returns the complext type directly.
+
+    ```java
+    package com.my.app;
+    ...
+    public class ExampleSnippet implements Snippet {
+        @Rpc(description = "Pass a complex type as a snippet parameter.")
+        public String passComplexTypeToSnippet(CustomType input) {
+            Log.i("Old value is: " + input.getMyValue());
+            return "The value in CustomType is: " + input.getMyValue();
+        }
+      
+        @Rpc(description = "Returns a complex type from snippet.")
+        public CustomType returnComplexTypeFromSnippet(String value) {
+            return new CustomType(value);
+        }
+        @Override
+        public void shutdown() {}
+    }
+    ```
+
+1.  In `AndroidManifest.xml`, specify the converter class as a `meta-data` named
+    `mobly-object-converter`
+
+    ```xml
+    <manifest
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        package="com.my.app">
+      <application>
+        <meta-data
+            android:name="mobly-object-converter"
+            android:value="com.my.app.ExampleObjectConverter" />
+        ...
+    ```
+
+## Running the example code
+
+This folder contains a fully working example of a standalone snippet apk.
+
+1.  Compile the example
+
+        ./gradlew examples:ex6_complex_type_conversion:assembleDebug
+
+1.  Install the apk on your phone
+
+        adb install -r ./examples/ex6_complex_type_conversion/build/outputs/apk/ex6_complex_type_conversion-debug.apk
+
+1.  Use Mobly's `snippet_shell` from mobly to trigger the Rpc methods:
+
+        snippet_shell.py com.google.android.mobly.snippet.example6
+
+        >>> s.passComplexTypeToSnippet({'Value': 'Hello'})
+        'The value in CustomType is: Hello'
+        >>> s.returnComplexTypeFromSnippet('Bye')
+        {'Value': 'Bye'}

--- a/examples/ex6_complex_type_conversion/build.gradle
+++ b/examples/ex6_complex_type_conversion/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
+
+    defaultConfig {
+        applicationId "com.google.android.mobly.snippet.example6"
+        minSdkVersion 16
+        targetSdkVersion 26
+        versionCode 1
+        versionName "0.0.1"
+    }
+    lintOptions {
+        abortOnError true
+        checkAllWarnings true
+        warningsAsErrors true
+    }
+}
+
+dependencies {
+    // The 'implementation project' dep is to compile against the snippet lib source in
+    // this repo. For your own snippets, you'll want to use the regular
+    // 'implementation' dep instead:
+    //implementation 'com.google.android.mobly:mobly-snippet-lib:1.2.0'
+    implementation project(':mobly-snippet-lib')
+}

--- a/examples/ex6_complex_type_conversion/src/main/AndroidManifest.xml
+++ b/examples/ex6_complex_type_conversion/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.android.mobly.snippet.example6">
+
+    <application>
+        <!-- Required: list of all classes with @Rpc methods. -->
+        <meta-data
+            android:name="mobly-snippets"
+            android:value="com.google.android.mobly.snippet.example6.ExampleSnippet" />
+        <!-- Optional: a class used for converting Java objects to/from JSON. -->
+        <meta-data
+            android:name="mobly-object-converter"
+            android:value="com.google.android.mobly.snippet.example6.ExampleObjectConverter" />
+        <meta-data
+          android:name="mobly-log-tag"
+          android:value="MoblySnippetLibExample6" />
+    </application>
+
+    <instrumentation
+        android:name="com.google.android.mobly.snippet.SnippetRunner"
+        android:targetPackage="com.google.android.mobly.snippet.example6" />
+</manifest>

--- a/examples/ex6_complex_type_conversion/src/main/java/com/google/android/mobly/snippet/example6/CustomType.java
+++ b/examples/ex6_complex_type_conversion/src/main/java/com/google/android/mobly/snippet/example6/CustomType.java
@@ -1,0 +1,21 @@
+package com.google.android.mobly.snippet.example6;
+
+/**
+ * A data class that defines a non-primitive type.
+ *
+ * This type is used to demonstrate serialization and de-serialization of complex type objects in
+ * Mobly Snippet Lib for Android.
+ */
+public class CustomType {
+    private String myValue;
+    CustomType(String value) {
+        myValue = value;
+    }
+
+    String getMyValue() {
+        return myValue;
+    }
+    public void setMyValue(String newValue) {
+        myValue = newValue;
+    }
+}

--- a/examples/ex6_complex_type_conversion/src/main/java/com/google/android/mobly/snippet/example6/ExampleObjectConverter.java
+++ b/examples/ex6_complex_type_conversion/src/main/java/com/google/android/mobly/snippet/example6/ExampleObjectConverter.java
@@ -1,0 +1,36 @@
+package com.google.android.mobly.snippet.example6;
+
+import android.os.Bundle;
+
+import com.google.android.mobly.snippet.SnippetObjectConverter;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.lang.reflect.Type;
+
+
+/**
+ * Example showing how to supply custom object converter to Mobly Snippet Lib.
+ */
+
+public class ExampleObjectConverter implements SnippetObjectConverter {
+    @Override
+    public JSONObject serialize(Object object) throws JSONException {
+        JSONObject result = new JSONObject();
+        if (object instanceof CustomType) {
+            CustomType input = (CustomType) object;
+            result.put("Value", input.getMyValue());
+            return result;
+        }
+        return null;
+    }
+
+    @Override
+    public Object deserialize(JSONObject jsonObject, Type type) throws JSONException {
+        if (type == CustomType.class) {
+            return new CustomType(jsonObject.getString("Value"));
+        }
+        return null;
+    }
+}

--- a/examples/ex6_complex_type_conversion/src/main/java/com/google/android/mobly/snippet/example6/ExampleSnippet.java
+++ b/examples/ex6_complex_type_conversion/src/main/java/com/google/android/mobly/snippet/example6/ExampleSnippet.java
@@ -43,8 +43,6 @@ public class ExampleSnippet implements Snippet {
 
     /**
      * Demonstrates serialization/de-serialization of a collection of custom type objects.
-     * @param objects
-     * @return
      */
     @Rpc(description = "Update values for multiple CustomType objects.")
     public ArrayList<CustomType> updateValues(ArrayList<CustomType> objects, String newValue) {

--- a/examples/ex6_complex_type_conversion/src/main/java/com/google/android/mobly/snippet/example6/ExampleSnippet.java
+++ b/examples/ex6_complex_type_conversion/src/main/java/com/google/android/mobly/snippet/example6/ExampleSnippet.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.example6;
+
+import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.rpc.Rpc;
+import com.google.android.mobly.snippet.util.Log;
+
+import java.util.ArrayList;
+
+/**
+ * Example snippet showing converting complex type objects using custom logic.
+ *
+ * For complex types in Java, one can supply a custom object converter to Snippet Lib to specify how
+ * each complex type should be serialized/de-serialized. With this, users don't have to explicitly
+ * call a serializer or de-serializer in every single Rpc method, which simplifies code.
+ */
+public class ExampleSnippet implements Snippet {
+    @Rpc(description = "Pass a complex type as a snippet parameter.")
+    public String passComplexTypeToSnippet(CustomType input) {
+        Log.i("Old value is: " + input.getMyValue());
+        return "The value in CustomType is: " + input.getMyValue();
+    }
+
+    @Rpc(description = "Returns a complex type from snippet.")
+    public CustomType returnComplexTypeFromSnippet(String value) {
+        return new CustomType(value);
+    }
+
+    /**
+     * Demonstrates serialization/de-serialization of a collection of custom type objects.
+     * @param objects
+     * @return
+     */
+    @Rpc(description = "Update values for multiple CustomType objects.")
+    public ArrayList<CustomType> updateValues(ArrayList<CustomType> objects, String newValue) {
+        for (CustomType obj : objects) {
+            obj.setMyValue(newValue);
+        }
+        return objects;
+    }
+
+    @Override
+    public void shutdown() {}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,5 +4,6 @@ include (
     ':examples:ex2_espresso',
     ':examples:ex3_async_event',
     ':examples:ex4_uiautomator',
-    ':examples:ex5_schedule_rpc')
+    ':examples:ex5_schedule_rpc',
+    ':examples:ex6_complex_type_conversion')
 project(":mobly-snippet-lib").projectDir = file('third_party/sl4a')

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetObjectConverter.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/SnippetObjectConverter.java
@@ -1,0 +1,39 @@
+package com.google.android.mobly.snippet;
+
+import java.lang.reflect.Type;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Interface for a converter that serializes and de-serializes objects.
+ *
+ * <p>Classes implementing this interface are meant to provide custom serialization/de-serialization
+ * logic for complex types.
+ *
+ * <p>Serialization here means converting a Java object to {@link JSONObject}, which can be
+ * transported over Snippet's Rpc protocol. De-serialization is this process in reverse.
+ */
+public interface SnippetObjectConverter {
+    /**
+     * Serializes a complex type object to {@link JSONObject}.
+     *
+     * <p>Return null to signify the complex type is not supported.
+     *
+     * @param object The object to convert to "serialize".
+     * @return A JSONObject representation of the input object, or `null` if the input object type
+     *     is not supported.
+     * @throws JSONException
+     */
+    JSONObject serialize(Object object) throws JSONException;
+
+    /**
+     * Deserializes a {@link JSONObject} to a Java complex type object.
+     *
+     * @param jsonObject A {@link JSONObject} passed from the Rpc client.
+     * @param type The expected {@link Type} of the Java object.
+     * @return A Java object of the specified {@link Type}, or `null` if the {@link Type} is not
+     *     supported.
+     * @throws JSONException
+     */
+    Object deserialize(JSONObject jsonObject, Type type) throws JSONException;
+}

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/manager/SnippetObjectConverterManager.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/manager/SnippetObjectConverterManager.java
@@ -1,0 +1,65 @@
+package com.google.android.mobly.snippet.manager;
+
+import com.google.android.mobly.snippet.SnippetObjectConverter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Manager for classes that implement {@link SnippetObjectConverter}.
+ *
+ * <p>This class is created to separate how Snippet Lib handles object conversion internally from
+ * how the conversion scheme for complex types is defined for users.
+ *
+ * <p>Snippet Lib can pull in the custom serializers and deserializers through here in various
+ * stages of execution, whereas users can have a clean interface for supplying these methods without
+ * worrying about internal states of Snippet Lib.
+ *
+ * <p>This gives us the flexibility of changing Snippet Lib internal structure or expanding support
+ * without impacting users. E.g. we can support multiple converter classes in the future.
+ */
+public class SnippetObjectConverterManager {
+    private static SnippetObjectConverter mConverter;
+    private static volatile SnippetObjectConverterManager mManager;
+
+    private SnippetObjectConverterManager() {}
+
+    public static synchronized SnippetObjectConverterManager getInstance() {
+        if (mManager == null) {
+            mManager = new SnippetObjectConverterManager();
+        }
+        return mManager;
+    }
+
+    static void addConverter(Class<? extends SnippetObjectConverter> converterClass) {
+        if (mConverter != null) {
+            throw new RuntimeException("A converter has been added, cannot add again.");
+        }
+        try {
+            mConverter = converterClass.getConstructor().newInstance();
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException("No default constructor found for the converter class.");
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e.getCause());
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Object objectToJson(Object object) throws JSONException {
+        if (mConverter == null) {
+            return null;
+        }
+        return mConverter.serialize(object);
+    }
+
+    public Object jsonToObject(JSONObject jsonObject, Type type) throws JSONException {
+        if (mConverter == null) {
+            return null;
+        }
+        return mConverter.deserialize(jsonObject, type);
+    }
+}

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonBuilder.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonBuilder.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.ParcelUuid;
+import com.google.android.mobly.snippet.manager.SnippetObjectConverterManager;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URL;
@@ -35,6 +36,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class JsonBuilder {
+
+    private JsonBuilder() {}
 
     @SuppressWarnings("unchecked")
     public static Object build(Object data) throws JSONException {
@@ -69,11 +72,11 @@ public class JsonBuilder {
             return data;
         }
         if (data instanceof Set<?>) {
-            List<Object> items = new ArrayList<Object>((Set<?>) data);
+            List<Object> items = new ArrayList<>((Set<?>) data);
             return buildJsonList(items);
         }
         if (data instanceof Collection<?>) {
-            List<Object> items = new ArrayList<Object>((Collection<?>) data);
+            List<Object> items = new ArrayList<>((Collection<?>) data);
             return buildJsonList(items);
         }
         if (data instanceof List<?>) {
@@ -86,8 +89,7 @@ public class JsonBuilder {
             return buildJsonIntent((Intent) data);
         }
         if (data instanceof Map<?, ?>) {
-            // TODO(damonkohler): I would like to make this a checked cast if
-            // possible.
+            // TODO(damonkohler): I would like to make this a checked cast if possible.
             return buildJsonMap((Map<String, ?>) data);
         }
         if (data instanceof ParcelUuid) {
@@ -112,7 +114,11 @@ public class JsonBuilder {
         if (data instanceof Object[]) {
             return buildJSONArray((Object[]) data);
         }
-
+        // Try with custom converter provided by user.
+        Object result = SnippetObjectConverterManager.getInstance().objectToJson(data);
+        if (result != null) {
+            return result;
+        }
         return data.toString();
     }
 
@@ -194,9 +200,5 @@ public class JsonBuilder {
 
     private static JSONObject buildUri(Uri uri) throws JSONException {
         return new JSONObject().put("Uri", build((uri != null) ? uri.toString() : ""));
-    }
-
-    private JsonBuilder() {
-        // This is a utility class.
     }
 }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonBuilder.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonBuilder.java
@@ -95,6 +95,7 @@ public class JsonBuilder {
         if (data instanceof ParcelUuid) {
             return data.toString();
         }
+        // TODO(xpconanfan): Deprecate the following default non-primitive type builders.
         if (data instanceof InetSocketAddress) {
             return buildInetSocketAddress((InetSocketAddress) data);
         }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
@@ -87,11 +87,7 @@ public final class MethodDescriptor {
         return manager.invoke(mClass, mMethod, args);
     }
 
-    /**
-     * Converts a parameter from JSON into a Java Object.
-     *
-     * @return TODO
-     */
+    /** Converts a parameter from JSON into a Java Object. */
     // TODO(damonkohler): This signature is a bit weird (auto-refactored). The obvious alternative
     // would be to work on one supplied parameter and return the converted parameter. However,
     // that's problematic because you lose the ability to call the getXXX methods on the JSON array.


### PR DESCRIPTION
This provides a syntactic sugar to make it easier to supply serializers and deserializers for a large set of non-primitive types.

Without this, snippet users have to explicitly call the converter methods each type a non-primitive type is passed in or returned. With this, snippet lib will try to use a user supplied converter for such types before falling back to the previous default option.

Added a new example project to demonstrate the usage of this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/86)
<!-- Reviewable:end -->

  