### PR TITLE
Fix a crash caused by custom converter

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/manager/SnippetManager.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/manager/SnippetManager.java
@@ -95,7 +95,11 @@ public class SnippetManager {
             throw new IllegalStateException("SnippetManager should not be re-initialized");
         }
         // Add custom object converter if user provided one.
-        SnippetObjectConverterManager.addConverter(findSnippetObjectConverterFromMetadata(context));
+        Class<? extends SnippetObjectConverter> converterClazz =
+                findSnippetObjectConverterFromMetadata(context);
+        if (converterClazz != null) {
+            SnippetObjectConverterManager.addConverter(converterClazz);
+        }
         Collection<Class<? extends Snippet>> classList = findSnippetClassesFromMetadata(context);
         sInstance = new SnippetManager(classList);
         return sInstance;

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/manager/SnippetManager.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/manager/SnippetManager.java
@@ -98,6 +98,7 @@ public class SnippetManager {
         Class<? extends SnippetObjectConverter> converterClazz =
                 findSnippetObjectConverterFromMetadata(context);
         if (converterClazz != null) {
+            Log.d("Found custom converter class, adding...");
             SnippetObjectConverterManager.addConverter(converterClazz);
         }
         Collection<Class<? extends Snippet>> classList = findSnippetClassesFromMetadata(context);


### PR DESCRIPTION
Snippet lib crashes if no custom converter class was provided.

@natalieharris

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/88)
<!-- Reviewable:end -->
