### PR TITLE
Add support for long arrays as snippet parameters

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
@@ -122,6 +122,13 @@ public final class MethodDescriptor {
                     result[i] = list.getInt(i);
                 }
                 return result;
+            } else if (type == Long[].class || type == long[].class) {
+                JSONArray list = parameters.getJSONArray(index);
+                Long[] result = new Long[list.length()];
+                for (int i = 0; i < list.length(); i++) {
+                    result[i] = list.getLong(i);
+                }
+                return result;
             } else if (type == Byte.class || type == byte[].class) {
                 JSONArray list = parameters.getJSONArray(index);
                 byte[] result = new byte[list.length()];


### PR DESCRIPTION
Specifying a snippet that takes a long array as a parameter, currently fails because there is no explicit conversion specified for the long array type. As a result, the "Try any custom converter provided" else block gets executed and fails because it tries to convert a JSONArray to a JSONObject.

Using an integer array as an alternative is also problematic, because the size of a Python integer can exceed the size of a Java integer.

This change adds explicit support for long arrays.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/105)
<!-- Reviewable:end -->
