### PR TITLE
Setting class loader before unmarshalling bundle to prevent java.lang…

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonBuilder.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonBuilder.java
@@ -146,6 +146,7 @@ public class JsonBuilder {
 
     private static JSONObject buildJsonBundle(Bundle bundle) throws JSONException {
         JSONObject result = new JSONObject();
+        bundle.setClassLoader(JsonBuilder.class.getClassLoader());
         for (String key : bundle.keySet()) {
             result.put(key, build(bundle.get(key)));
         }


### PR DESCRIPTION
Setting class loader before unmarshalling bundle to prevent java.lang.ClassNotFoundException.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/114)
<!-- Reviewable:end -->
