### PR TITLE
Support RpcOptional for RPC arguments

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/RpcOptional.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/RpcOptional.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.rpc;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation to mark RPC parameter as optional.
+ *
+ * <p>The parameter marked as optional has no explicit default value. {@code null} is used as
+ * default value.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Documented
+public @interface RpcOptional {}


### PR DESCRIPTION
With this annotation, arguments which are not present when calling will be assign `null` value by default.

Usage:
```java
@Rpc(description = "Returns true if value is null, false otherwise.")
public boolean isValueNull(@RpcOptional Integer value) {
    return value == null;
}
```

```Python
assert mbs.isValueNull()==True
assert mbs.isValueNull(0)==False
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/122)
<!-- Reviewable:end -->
