### PR TITLE
Support RpcDefault for RPC arguments

### DIFF
--- a/examples/ex7_default_and_optional_rpc/README.md
+++ b/examples/ex7_default_and_optional_rpc/README.md
@@ -1,0 +1,51 @@
+# Default and Optional RPCs Example
+
+This example shows you how to use `RpcDefault` and `RpcOptional` which is built
+into Mobly snippet lib to annotate RPC's parameters.
+
+## Why this is needed?
+
+These annotations can be used to specify the default and optional parameters for
+RPC methods, which allows developers to create more flexible and reusable RPC
+methods.
+
+Here are some additional benefits of using `RpcDefault` and `RpcOptional`:
+
+  - Improve the readability and maintainability of RPC methods.
+  - Prevent errors caused by missing or invalid parameters.
+  - Make it easier to test RPC methods.
+
+See the source code ExampleDefaultAndOptionalRpcSnippet.java for details.
+
+## Running the example code
+
+This folder contains a fully working example of a standalone snippet apk.
+
+1.  Compile the example
+
+        ./gradlew examples:ex7_default_and_optional_rpc:assembleDebug
+
+1.  Install the apk on your phone
+
+        adb install -r ./examples/ex7_default_and_optional_rpc/build/outputs/apk/debug/ex7_default_and_optional_rpc-debug.apk
+
+1.  Use `snippet_shell` from mobly to trigger `makeToast()`:
+
+        snippet_shell.py com.google.android.mobly.snippet.example7
+
+        >>> s.makeToast('Hello')
+
+        Wait for `Hello, bool:true` message to show up on the screen. Here we
+        didn't provide a Boolean to the RPC, so a default value, true, is used.
+
+        >>> s.makeToast('Hello', False)
+
+        Wait for `Hello, bool:false` message to show up on the screen. Here we
+        provide a Boolean to the RPC, so the value is used instead of using
+        default value.
+
+        >>> s.makeToast('Hello', False, 1)
+
+        Wait for `Hello, bool:false, number: 1` message to show up on the
+        screen. The number is an optional parameter, it only shows up when we
+        pass a value to the RPC.

--- a/examples/ex7_default_and_optional_rpc/build.gradle
+++ b/examples/ex7_default_and_optional_rpc/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 31
+    buildToolsVersion '31.0.0'
+
+    defaultConfig {
+        applicationId "com.google.android.mobly.snippet.example7"
+        minSdkVersion 26
+        targetSdkVersion 31
+        versionCode 1
+        versionName "0.0.1"
+    }
+    lintOptions {
+        abortOnError true
+        checkAllWarnings true
+        warningsAsErrors true
+    }
+}
+
+dependencies {
+    // The 'implementation project' dep is to compile against the snippet lib source in
+    // this repo. For your own snippets, you'll want to use the regular
+    // 'implementation' dep instead:
+    //implementation 'com.google.android.mobly:mobly-snippet-lib:1.3.1'
+    implementation project(':mobly-snippet-lib')
+}

--- a/examples/ex7_default_and_optional_rpc/src/main/AndroidManifest.xml
+++ b/examples/ex7_default_and_optional_rpc/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.android.mobly.snippet.example7">
+
+    <application android:allowBackup="false">
+        <meta-data
+            android:name="mobly-snippets"
+            android:value="com.google.android.mobly.snippet.example7.ExampleDefaultAndOptionalRpcSnippet" />
+    </application>
+
+    <instrumentation
+        android:name="com.google.android.mobly.snippet.SnippetRunner"
+        android:targetPackage="com.google.android.mobly.snippet.example7" />
+
+</manifest>

--- a/examples/ex7_default_and_optional_rpc/src/main/java/com/google/android/mobly/snippet/example7/ExampleDefaultAndOptionalRpcSnippet.java
+++ b/examples/ex7_default_and_optional_rpc/src/main/java/com/google/android/mobly/snippet/example7/ExampleDefaultAndOptionalRpcSnippet.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.example7;
+
+import android.content.Context;
+import android.os.Handler;
+import android.widget.Toast;
+import androidx.test.InstrumentationRegistry;
+import com.google.android.mobly.snippet.Snippet;
+import com.google.android.mobly.snippet.event.EventCache;
+import com.google.android.mobly.snippet.rpc.Rpc;
+import com.google.android.mobly.snippet.rpc.RpcDefault;
+import com.google.android.mobly.snippet.rpc.RpcOptional;
+
+/** Demonstrates how to mark an RPC has default value or optional. */
+public class ExampleDefaultAndOptionalRpcSnippet implements Snippet {
+
+    private final Context mContext;
+    private final EventCache mEventCache = EventCache.getInstance();
+
+    /**
+     * Since the APIs here deal with UI, most of them have to be called in a thread that has called
+     * looper.
+     */
+    private final Handler mHandler;
+
+    public ExampleDefaultAndOptionalRpcSnippet() {
+        mContext = InstrumentationRegistry.getContext();
+        mHandler = new Handler(mContext.getMainLooper());
+    }
+
+    @Rpc(description = "Make a toast on screen.")
+    public String makeToast(
+            String message, @RpcDefault("true") Boolean bool, @RpcOptional Integer number)
+            throws InterruptedException {
+        if (number == null) {
+            showToast(String.format("%s, bool:%b", message, bool));
+        } else {
+            showToast(String.format("%s, bool:%b, number:%d", message, bool, number));
+        }
+        return "OK";
+    }
+
+    @Override
+    public void shutdown() {}
+
+    private void showToast(final String message) {
+        mHandler.post(
+            new Runnable() {
+                @Override
+                public void run() {
+                    Toast.makeText(mContext, message, Toast.LENGTH_LONG).show();
+                }
+            });
+    }
+}

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
@@ -23,18 +23,23 @@ import com.google.android.mobly.snippet.manager.SnippetManager;
 import com.google.android.mobly.snippet.manager.SnippetObjectConverterManager;
 import com.google.android.mobly.snippet.util.AndroidUtil;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 /** An adapter that wraps {@code Method}. */
 public final class MethodDescriptor {
+    private static final Map<Class<?>, TypeConverter<?>> typeConverters = populateConverters();
+
     private final Method mMethod;
     private final Class<? extends Snippet> mClass;
 
@@ -222,10 +227,6 @@ public final class MethodDescriptor {
         return mClass;
     }
 
-    public Annotation[][] getParameterAnnotations() {
-        return mMethod.getParameterAnnotations();
-    }
-
     private String getAnnotationDescription() {
         if (isAsync()) {
             AsyncRpc annotation = mMethod.getAnnotation(AsyncRpc.class);
@@ -233,6 +234,10 @@ public final class MethodDescriptor {
         }
         Rpc annotation = mMethod.getAnnotation(Rpc.class);
         return annotation.description();
+    }
+
+    public Annotation[][] getParameterAnnotations() {
+        return mMethod.getParameterAnnotations();
     }
 
     /**
@@ -267,11 +272,38 @@ public final class MethodDescriptor {
      */
     public static Object getDefaultValue(Type parameterType, Annotation[] annotations) {
         for (Annotation a : annotations) {
-            if (a instanceof RpcOptional) {
+            if (a instanceof RpcDefault) {
+                RpcDefault defaultAnnotation = (RpcDefault) a;
+                TypeConverter<?> converter =
+                        converterFor(parameterType, defaultAnnotation.converter());
+                return converter.convert(defaultAnnotation.value());
+            } else if (a instanceof RpcOptional) {
                 return null;
             }
         }
         throw new IllegalStateException("No default value for " + parameterType);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static TypeConverter<?> converterFor(
+            Type parameterType, Class<? extends TypeConverter> converterClass) {
+        if (converterClass == TypeConverter.class) {
+            TypeConverter<?> converter = typeConverters.get(parameterType);
+            if (converter == null) {
+                throw new IllegalArgumentException(
+                        String.format("No predefined converter found for %s", parameterType));
+            }
+            return converter;
+        }
+        try {
+            Constructor<?> constructor = converterClass.getConstructor(new Class<?>[0]);
+            return (TypeConverter<?>) constructor.newInstance(new Object[0]);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Cannot create converter from %s", converterClass.getCanonicalName()),
+                    e);
+        }
     }
 
     /**
@@ -281,11 +313,63 @@ public final class MethodDescriptor {
      */
     public static boolean hasDefaultValue(Annotation[] annotations) {
         for (Annotation a : annotations) {
-            if (a instanceof RpcOptional) {
+            if (a instanceof RpcDefault || a instanceof RpcOptional) {
                 return true;
             }
         }
         return false;
     }
 
+    /**
+     * Returns the converters for {@code String}, {@code Integer}, {@code Long},
+     * and {@code Boolean}.
+     */
+    private static Map<Class<?>, TypeConverter<?>> populateConverters() {
+        Map<Class<?>, TypeConverter<?>> converters = new HashMap<>();
+        converters.put(String.class, new TypeConverter<String>() {
+            @Override
+            public String convert(String value) {
+                return value;
+            }
+        });
+        converters.put(Integer.class, new TypeConverter<Integer>() {
+            @Override
+            public Integer convert(String input) {
+                try {
+                    return Integer.decode(input);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException(
+                            String.format("'%s' is not a Integer", input), e);
+                }
+            }
+        });
+        converters.put(Long.class, new TypeConverter<Long>() {
+            @Override
+            public Long convert(String input) {
+                try {
+                    return Long.decode(input);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException(
+                            String.format("'%s' is not a Long", input), e);
+                }
+            }
+        });
+        converters.put(Boolean.class, new TypeConverter<Boolean>() {
+            @Override
+            public Boolean convert(String input) {
+                if (input == null) {
+                    return null;
+                }
+                input = input.toLowerCase(Locale.ROOT);
+                if (input.equals("true")) {
+                    return Boolean.TRUE;
+                }
+                if (input.equals("false")) {
+                    return Boolean.FALSE;
+                }
+                throw new IllegalArgumentException(String.format("'%s' is not a Boolean", input));
+            }
+        });
+        return converters;
+    }
 }

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/RpcDefault.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/RpcDefault.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.rpc;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use this annotation to mark an RPC parameter that have a default value.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Documented
+public @interface RpcDefault {
+    /** The default value of the RPC parameter. */
+    String value();
+
+    @SuppressWarnings("rawtypes")
+    Class<? extends TypeConverter> converter() default TypeConverter.class;
+}

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/TypeConverter.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/TypeConverter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.android.mobly.snippet.rpc;
+
+/**
+ * A converter can take a String and turn it into an instance of type T (the type parameter to the
+ * converter).
+ */
+public interface TypeConverter<T> {
+
+    /** Convert a string into type T. */
+    T convert(String value);
+}


### PR DESCRIPTION
With this annotation, arguments which are not present when calling will be assigned a default value.

Support types: String, Integer, Long, and Boolean.

Usage:

```java
    @Rpc(description = "Make a toast on screen.")
    public String makeToast(
            String message, @RpcDefault("true") Boolean bool, @RpcOptional Integer number)
            throws InterruptedException {
        if (number == null) {
            showToast(String.format("%s, bool:%b", message, bool));
        } else {
            showToast(String.format("%s, bool:%b, number:%d", message, bool, number));
        }
        return "OK";
    }
```
        >>> s.makeToast('Hello')
        Wait for `Hello, bool:true` message to show up on the screen. Here we
        didn't provide a Boolean to the RPC, so a default value, true, is used.

        >>> s.makeToast('Hello', False)
        Wait for `Hello, bool:false` message to show up on the screen. Here we
        provide a Boolean to the RPC, so the value is used instead of using
        default value.

        >>> s.makeToast('Hello', False, 1)
        Wait for `Hello, bool:false, number: 1` message to show up on the
        screen. The number is an optional parameter, it only shows up when we
        pass a value to the RPC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/123)
<!-- Reviewable:end -->
