### PR TITLE
Fix Java style, lint, and best practices warning.

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/RpcError.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/RpcError.java
@@ -22,4 +22,8 @@ public class RpcError extends Exception {
     public RpcError(String message) {
         super(message);
     }
+
+    public RpcError(String message, Throwable cause) {
+        super(message, cause);
+    }
 }


### PR DESCRIPTION
1. Java Style - MixedArrayDimensions

	C-style array declarations should not be used

	```
	int foos[]; (X)
        int[] foos; (O)
	```

2. Java Lint - UnusedException

	New exception to be thrown should include the caught exception as its cause.

	```
	try {
 		// do stuff } catch (InnerException e) { // set e as cause of the new exception throw new OuterException("Failed to do something", e); } ```

3. Java Api Best Practices - AvoidObjectArrays

	Avoid accepting a Annotation[]; consider an Iterable<Annotation> instead

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/124)
<!-- Reviewable:end -->
