### PR TITLE
Check for null pointer in SimpleServer#getPrivateInetAddress

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/SimpleServer.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/SimpleServer.java
@@ -138,17 +138,19 @@ public abstract class SimpleServer {
 
         InetAddress candidate = null;
         Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
-        for (NetworkInterface netint : Collections.list(nets)) {
-            if (!netint.isLoopback() || !netint.isUp()) { // Ignore if localhost or not active
-                continue;
-            }
-            Enumeration<InetAddress> addresses = netint.getInetAddresses();
-            for (InetAddress address : Collections.list(addresses)) {
-                if (address instanceof Inet4Address) {
-                    Log.d("local address " + address);
-                    return address; // Prefer ipv4
+        if (nets != null) {
+            for (NetworkInterface netint : Collections.list(nets)) {
+                if (!netint.isLoopback() || !netint.isUp()) { // Ignore if localhost or not active
+                    continue;
                 }
-                candidate = address; // Probably an ipv6
+                Enumeration<InetAddress> addresses = netint.getInetAddresses();
+                for (InetAddress address : Collections.list(addresses)) {
+                    if (address instanceof Inet4Address) {
+                        Log.d("local address " + address);
+                        return address; // Prefer ipv4
+                    }
+                    candidate = address; // Probably an ipv6
+                }
             }
         }
         if (candidate != null) {

--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/SimpleServer.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/SimpleServer.java
@@ -138,19 +138,20 @@ public abstract class SimpleServer {
 
         InetAddress candidate = null;
         Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
-        if (nets != null) {
-            for (NetworkInterface netint : Collections.list(nets)) {
-                if (!netint.isLoopback() || !netint.isUp()) { // Ignore if localhost or not active
-                    continue;
+        if (nets == null) {
+            return InetAddress.getLocalHost(); // Return local host if no interfaces found.
+        }
+        for (NetworkInterface netint : Collections.list(nets)) {
+            if (!netint.isLoopback() || !netint.isUp()) { // Ignore if localhost or not active
+                continue;
+            }
+            Enumeration<InetAddress> addresses = netint.getInetAddresses();
+            for (InetAddress address : Collections.list(addresses)) {
+                if (address instanceof Inet4Address) {
+                    Log.d("local address " + address);
+                    return address; // Prefer ipv4
                 }
-                Enumeration<InetAddress> addresses = netint.getInetAddresses();
-                for (InetAddress address : Collections.list(addresses)) {
-                    if (address instanceof Inet4Address) {
-                        Log.d("local address " + address);
-                        return address; // Prefer ipv4
-                    }
-                    candidate = address; // Probably an ipv6
-                }
+                candidate = address; // Probably an ipv6
             }
         }
         if (candidate != null) {


### PR DESCRIPTION
On certain devices it is possible for NetworkInterface#getNetworkInterfaces to return `null`. Add a check to prevent the main loop from throwing a `NullPointerException`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/130)
<!-- Reviewable:end -->
