### PR TITLE
Support handling data type Byte in snippet method return values

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonBuilder.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/JsonBuilder.java
@@ -40,6 +40,9 @@ public class JsonBuilder {
         if (data == null) {
             return JSONObject.NULL;
         }
+        if (data instanceof Byte) {
+            return (Byte) data & 0xFF;
+        }
         if (data instanceof Integer) {
             return data;
         }


### PR DESCRIPTION
Current behavior:

Java returns a `byte[]` -> Python receives int list
Java returns a `Byte[]` -> Python receives string list

So we want to fix the gap. Whether Java returns a `byte[]` or `Byte[]`, it should be passed to python as a int list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/mobly-snippet-lib/137)
<!-- Reviewable:end -->
