### PR TITLE
Support passing in int for enum parameters in MethodDescriptor.

### DIFF
--- a/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
+++ b/third_party/sl4a/src/main/java/com/google/android/mobly/snippet/rpc/MethodDescriptor.java
@@ -132,6 +132,8 @@ public final class MethodDescriptor {
                 return parameters.getDouble(index);
             } else if (type == Integer.class || type == int.class) {
                 return parameters.getInt(index);
+            } else if (type instanceof Class && ((Class) type).isEnum()) {
+                return ((Class) type).getEnumConstants()[parameters.getInt(index)];
             } else if (type == Intent.class) {
                 return buildIntent(parameters.getJSONObject(index));
             } else if (type == String.class) {


### PR DESCRIPTION
Currently an Enum parameter received as int will fall into the else branch and be processed by custom converters, but an int is not directly convertible into a JsonObject and will fail the parameters.getJsonObject call below.